### PR TITLE
fix: pass token to workflow

### DIFF
--- a/.github/workflows/yarn-lint.yml
+++ b/.github/workflows/yarn-lint.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: yarn install
         run: |

--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: yarn install
         run: |


### PR DESCRIPTION
This PR attempts to fix the missing token on the github actions excecution